### PR TITLE
remove invalid import preventing changes from deploying

### DIFF
--- a/pocs-capstone/frontend/src/components/MainMobile.js
+++ b/pocs-capstone/frontend/src/components/MainMobile.js
@@ -8,7 +8,6 @@ import CalendarPageMobile from "./CalendarMobile/CalendarPageMobile.js";
 import TaskPageMobile from "./PageDisplay/TaskMobile/TaskPageMobile.js";
 import ProfileAccountPageMobile from "./ProfileAccountPageMobile";
 import { Tabs, Tab } from '@material-ui/core';
-import ImageIcon from '@material-ui/icons/Image';
 import InventoryIcon from '@mui/icons-material/Inventory';
 import {List, PersonPin, CalendarToday, } from '@material-ui/icons';
 const MainMobile = () => {


### PR DESCRIPTION
removes and unused import that we should remove rather than install because we are not using the material ui components anywhere in the application that the missing module imports